### PR TITLE
Show state/region in table after adding a company

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -33,7 +33,7 @@ export const addCompany = async (
   owner,
   phone,
   city,
-  state_region,
+  state,
   postalCode,
   logo,
   industry
@@ -43,7 +43,7 @@ export const addCompany = async (
     owner,
     phone,
     city,
-    state_region,
+    state,
     postalCode,
     logo,
     industry,


### PR DESCRIPTION
When adding a new company, the state/region wasn't showing up in the table.  This fixes that issue.